### PR TITLE
m8: don't use LOCAL_PATH macro for overlay

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -15,7 +15,7 @@
 #
 
 # Local overlays
-DEVICE_PACKAGE_OVERLAYS += $(LOCAL_PATH)/overlay
+DEVICE_PACKAGE_OVERLAYS += device/htc/m8/overlay
 
 # Inherit from m8-common
 $(call inherit-product, device/htc/m8-common/m8-common.mk)


### PR DESCRIPTION
- this doesn't typically work right when we inherit common device
  repos

Change-Id: Ib1ddf65fe5643fb0dd4886b58d004aef3f97a10c
