### PR TITLE
[HACK] m8: don't start rild until after boot completed

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -19,3 +19,7 @@ DEVICE_PACKAGE_OVERLAYS += device/htc/m8/overlay
 
 # Inherit from m8-common
 $(call inherit-product, device/htc/m8-common/m8-common.mk)
+
+# Init
+PRODUCT_PACKAGES += \
+    init.variant.rc

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -1,0 +1,10 @@
+LOCAL_PATH:= $(call my-dir)
+include $(CLEAR_VARS)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE       := init.variant.rc
+LOCAL_MODULE_TAGS  := optional eng
+LOCAL_MODULE_CLASS := ETC
+LOCAL_SRC_FILES    := etc/init.variant.rc
+LOCAL_MODULE_PATH  := $(TARGET_ROOT_OUT)
+include $(BUILD_PREBUILT)

--- a/rootdir/etc/init.variant.rc
+++ b/rootdir/etc/init.variant.rc
@@ -1,0 +1,11 @@
+service_redefine ril-daemon /system/bin/rild
+    class main
+    socket rild stream 660 root radio
+    socket sap_uim_socket1 stream 660 bluetooth bluetooth
+    socket rild-debug stream 660 radio system
+    user root
+    group radio cache inet misc audio log qcom_diag
+    disabled
+
+on property:sys.boot_completed=1
+    start ril-daemon


### PR DESCRIPTION
- For whatever reason m8vzw (at least) won't boot with data
  somewhere around 75% of the time. Killing rild fixes the issue
  until another reboot. Fuck the race condition real hard and
  start rild way late.
- By admitting that I'm not proud of this patch, I automatically
  absolve myself of any wrong-doing.

Change-Id: I51661cafc1d5cd0108537329fb4bb14eb6469188
